### PR TITLE
fix: use dataVersion to determine version

### DIFF
--- a/core/src/main/java/me/deadlight/ezchestshop/utils/Utils.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/Utils.java
@@ -85,8 +85,6 @@ public class Utils {
                 } else if (dataVersion >= 2556) {
                   internalsName = "v1_16_R3"
                 }
-            }
-
                 
                 versionUtils = (VersionUtils) Class.forName(packageName + "." + internalsName).newInstance();
             }

--- a/core/src/main/java/me/deadlight/ezchestshop/utils/Utils.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/Utils.java
@@ -70,7 +70,24 @@ public class Utils {
                 versionUtils = (VersionUtils) Class.forName("me.deadlight.ezchestshop.utils.v1_20_R3").newInstance();
             } else {
                 String packageName = Utils.class.getPackage().getName();
-                String internalsName = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+                String internalsName = "";
+                
+                int dataVersion = Bukkit.getUnsafe().getDataVersion();
+                
+                if (dataVersion >= 3454) {
+                  internalsName = "v1_20_R3"
+                } else if (dataVersion >= 3098) {
+                  internalsName = "v1_19_R3"
+                } else if (dataVersion >= 2847) {
+                  internalsName = "v1_18_R2"
+                } else if (dataVersion >= 2716) {
+                  internalsName = "v1_17_R1"
+                } else if (dataVersion >= 2556) {
+                  internalsName = "v1_16_R3"
+                }
+            }
+
+                
                 versionUtils = (VersionUtils) Class.forName(packageName + "." + internalsName).newInstance();
             }
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException


### PR DESCRIPTION
Use dataVersion to determine version since Paper 1.20.5+ no longer relocates CraftBukkit versions.